### PR TITLE
Fix ParameterGroup content container

### DIFF
--- a/view/components/ParameterGroup.qml
+++ b/view/components/ParameterGroup.qml
@@ -3,8 +3,8 @@ import QtQuick.Controls 2.15
 
 Item {
     id: root
+    default property alias content: contentContainer.data
     property alias title: titleText.text
-    property alias content: contentContainer
 
     Column {
         anchors.fill: parent; spacing: 8


### PR DESCRIPTION
## Summary
- allow unqualified children of `ParameterGroup` to populate `contentContainer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886da1b91048331bb6ba5d42093123f